### PR TITLE
fix: pin argos version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,8 @@
   ansible.builtin.git:
     repo: "https://github.com/p-e-w/argos.git"
     dest: "/usr/local/share/gnome-shell/extensions"
+    version: "GNOME-44"
+    force: yes
 
 - name: Install (de-) activate script for user
   ansible.builtin.copy:


### PR DESCRIPTION
since today (yesterday), the argos menus did not work any more (on ubuntu 2204). It seems that one of the [recent merges](https://github.com/p-e-w/argos/pulls?q=is%3Apr+is%3Aclosed) broke gnome 42.9 compatitibility (on ubuntu 2204).

The old implementation was too simplistic anyway.